### PR TITLE
大佬，发现您的项目引入了org.eclipse.jetty:jetty-server@9.1.0.M0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.deem</groupId>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.1.0.M0</version>
+            <version>9.4.41</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Eclipse Jetty 信息泄露漏洞
缺陷组件：org.eclipse.jetty:jetty-server@9.1.0.M0
漏洞编号：CVE-2019-10247
漏洞描述：Eclipse Jetty是Eclipse基金会的一个开源的、基于Java的Web服务器和Java Servlet容器。
Eclipse Jetty中存在安全漏洞。攻击者可利用该漏洞泄露信息。以下版本受到影响：Eclipse Jetty 7.x版本，8.x版本，9.2.27及之前版本，9.3.26及之前版本，9.4.16及之前版本。
影响范围：[7.0.0.M0, 9.2.28.v20190418)
最小修复版本：9.4.41
缺陷组件引入路径：com.deem:zkui@2.0-SNAPSHOT->org.eclipse.jetty:jetty-server@9.1.0.M0
```
另外我运行这个项目时，IDE的安全插件提示还有26个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=paabed